### PR TITLE
Refactor syndications models

### DIFF
--- a/app/controllers/francis_cms/syndications_controller.rb
+++ b/app/controllers/francis_cms/syndications_controller.rb
@@ -5,7 +5,13 @@ module FrancisCms
     before_action :require_login
 
     def create
-      save_syndication(SyndicationInput.new(params).to_h)
+      @syndication = syndicatable.syndications.new(SyndicationInput.new(params).to_h)
+
+      if @syndication.save
+        flash[:notice] = t('flashes.syndications.create_notice')
+      else
+        flash[:alert] = t('flashes.syndications.create_alert')
+      end
 
       redirect_to send("edit_#{resource_type.singularize}_path", syndicatable)
     end
@@ -17,16 +23,11 @@ module FrancisCms
     end
 
     def flickr
-      begin
-        photo_title = syndicatable.title
-        photo_description = "#{syndicatable.to_html.lines[1..-1].join.chomp}\n\nOriginally published at #{photo_url(syndicatable)}."
-        photo_tags = syndicatable.tags.collect { |tag| %{"#{tag}"} }.join(' ')
+      @syndication = syndicatable.syndications.new(Syndications::Flickr.new(syndicatable, canonical_url).publish)
 
-        flickr_photo_id = Flickr.upload(syndicatable.photo.path, title: photo_title, description: photo_description, tags: photo_tags)
-        flickr_photo_url = "https://www.flickr.com/photos/#{Flickr.photos.find(flickr_photo_id).get_info!.owner.username}/#{flickr_photo_id}/"
-
-        save_syndication({ name: 'Flickr', url: flickr_photo_url })
-      rescue
+      if @syndication.save
+        flash[:notice] = t('flashes.syndications.flickr_create_notice')
+      else
         flash[:alert] = t('flashes.syndications.flickr_create_alert')
       end
 
@@ -34,27 +35,11 @@ module FrancisCms
     end
 
     def medium
-      begin
-        canonical_url = send("#{resource_type.singularize}_url", syndicatable)
+      @syndication = syndicatable.syndications.new(Syndications::Medium.new(syndicatable, canonical_url).publish)
 
-        options = {
-          title: syndicatable.title,
-          content_format: 'html',
-          content: %{<h1>#{syndicatable.title}</h1>#{syndicatable.to_html}<hr><p><i>This post was originally published on <a href="#{canonical_url}" rel="canonical">my own site</a>.</i></p>},
-          canonical_url: canonical_url,
-          license: 'cc-40-by-nc-sa'
-        }
-
-        if syndicatable.tags.any?
-          options[:tags] = syndicatable.tags[0..2].collect { |tag| tag.name }
-        end
-
-        response = MediumClient.posts.create(MediumClient.users.me, options)
-
-        medium_url = JSON.parse(response.body)['data']['url']
-
-        save_syndication({ name: 'Medium', url: medium_url })
-      rescue
+      if @syndication.save
+        flash[:notice] = t('flashes.syndications.medium_create_notice')
+      else
         flash[:alert] = t('flashes.syndications.medium_create_alert')
       end
 
@@ -62,30 +47,11 @@ module FrancisCms
     end
 
     def twitter
-      begin
-        url = syndicatable.is_link? ? syndicatable.url : send("#{resource_type.singularize}_url", syndicatable)
-        options = {}
+      @syndication = syndicatable.syndications.new(Syndications::Twitter.new(syndicatable, canonical_url).publish)
 
-        if syndicatable.try(:geolocated?) && syndicatable.geolocated?
-          places = TwitterClient.reverse_geocode({ lat: syndicatable.latitude, long: syndicatable.longitude })
-
-          if places.any?
-            options[:place] = places.first
-          end
-        end
-
-        if syndicatable.is_photo?
-          status = syndicatable.title.truncate(90, omission: '…', separator: ' ')
-          tweet = TwitterClient.update_with_media("#{status} – #{url}", File.new(syndicatable.photo.path), options)
-        else
-          status = syndicatable.title.truncate(114, omission: '…', separator: ' ')
-          tweet = TwitterClient.update("#{status} – #{url}", options)
-        end
-
-        tweet_url = "https://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id}"
-
-        save_syndication({ name: 'Twitter', url: tweet_url })
-      rescue
+      if @syndication.save
+        flash[:notice] = t('flashes.syndications.twitter_create_notice')
+      else
         flash[:alert] = t('flashes.syndications.twitter_create_alert')
       end
 
@@ -94,18 +60,12 @@ module FrancisCms
 
     private
 
-    def parent_class
-      @parent_class ||= "FrancisCms::#{resource_type.classify}".constantize
+    def canonical_url
+      @canonical_url ||= send("#{resource_type.singularize}_url", syndicatable)
     end
 
-    def save_syndication(params)
-      @syndication = syndicatable.syndications.new(params)
-
-      if @syndication.save
-        flash[:notice] = t('flashes.syndications.create_notice')
-      else
-        flash[:alert] = t('flashes.syndications.create_alert')
-      end
+    def parent_class
+      @parent_class ||= "FrancisCms::#{resource_type.classify}".constantize
     end
 
     def syndicatable

--- a/app/models/francis_cms/syndications/flickr.rb
+++ b/app/models/francis_cms/syndications/flickr.rb
@@ -1,0 +1,41 @@
+module FrancisCms
+  module Syndications
+    class Flickr
+      def initialize(syndicatable, canonical_url)
+        @syndicatable = syndicatable
+        @canonical_url = canonical_url
+
+        @client = ::Flickr
+
+        @client.configure({
+          api_key:             Rails.application.secrets.flickr_api_key
+          shared_secret:       Rails.application.secrets.flickr_shared_secret
+          access_token_key:    Rails.application.secrets.flickr_access_token_key
+          access_token_secret: Rails.application.secrets.flickr_access_token_secret
+        })
+      end
+
+      def publish
+        photo_id = @client.upload(@syndicatable.photo.path, options)
+        username = @client.photos.find(photo_id).get_info!.owner.username
+
+        {
+          name: 'Flickr',
+          url: "https://www.flickr.com/photos/#{username}/#{photo_id}/"
+        }
+      rescue => error
+        # log `error.message`
+      end
+
+      private
+
+      def options
+        {
+          title: @syndicatable.title,
+          description: "#{@syndicatable.to_html.lines.drop(1).join.chomp}\n\nOriginally published at #{@canonical_url}.",
+          tags: @syndicatable.tags.collect { |tag| %{"#{tag}"} }.join(' ')
+        }
+      end
+    end
+  end
+end

--- a/app/models/francis_cms/syndications/flickr.rb
+++ b/app/models/francis_cms/syndications/flickr.rb
@@ -1,18 +1,20 @@
 module FrancisCms
   module Syndications
     class Flickr
+      CLIENT_PARAMS = {
+        api_key:             Rails.application.secrets.flickr_api_key,
+        shared_secret:       Rails.application.secrets.flickr_shared_secret,
+        access_token_key:    Rails.application.secrets.flickr_access_token_key,
+        access_token_secret: Rails.application.secrets.flickr_access_token_secret
+      }
+
       def initialize(syndicatable, canonical_url)
         @syndicatable = syndicatable
         @canonical_url = canonical_url
 
         @client = ::Flickr
 
-        @client.configure({
-          api_key:             Rails.application.secrets.flickr_api_key
-          shared_secret:       Rails.application.secrets.flickr_shared_secret
-          access_token_key:    Rails.application.secrets.flickr_access_token_key
-          access_token_secret: Rails.application.secrets.flickr_access_token_secret
-        })
+        @client.configure(CLIENT_PARAMS)
       end
 
       def publish

--- a/app/models/francis_cms/syndications/medium.rb
+++ b/app/models/francis_cms/syndications/medium.rb
@@ -1,13 +1,15 @@
 module FrancisCms
   module Syndications
     class Medium
+      CLIENT_PARAMS = {
+        integration_token: Rails.application.secrets.medium_integration_token
+      }
+
       def initialize(syndicatable, canonical_url)
         @syndicatable = syndicatable
         @canonical_url = canonical_url
 
-        @client = ::Medium::Client.new({
-          integration_token: Rails.application.secrets.medium_integration_token
-        })
+        @client = ::Medium::Client.new(CLIENT_PARAMS)
       end
 
       def publish

--- a/app/models/francis_cms/syndications/medium.rb
+++ b/app/models/francis_cms/syndications/medium.rb
@@ -1,0 +1,51 @@
+module FrancisCms
+  module Syndications
+    class Medium
+      def initialize(syndicatable, canonical_url)
+        @syndicatable = syndicatable
+        @canonical_url = canonical_url
+
+        @client = ::Medium::Client.new({
+          integration_token: Rails.application.secrets.medium_integration_token
+        })
+      end
+
+      def publish
+        response = @client.posts.create(@client.users.me, options)
+
+        {
+          name: 'Medium',
+          url: JSON.parse(response.body)['data']['url']
+        }
+      rescue => error
+        # log `error.message`
+      end
+
+      private
+
+      def options
+        {
+          title: @syndicatable.title,
+          content_format: 'html',
+          content: post_content,
+          canonical_url: @canonical_url,
+          tags: post_tags,
+          license: 'cc-40-by-nc-sa'
+        }
+      end
+
+      def post_content
+        %{
+          <h1>#{@syndicatable.title}</h1>
+          #{@syndicatable.to_html.gsub(/\shref="\//, %{ href="#{FrancisCms.configuration.site_url}})}
+          <hr>
+          <p><i>This post was originally published on <a href="#{@canonical_url}" rel="canonical">my own site</a>.</i></p>
+        }
+      end
+
+      def post_tags
+        @syndicatable.tags.take(3).collect(&:name)
+      end
+    end
+  end
+end

--- a/app/models/francis_cms/syndications/twitter.rb
+++ b/app/models/francis_cms/syndications/twitter.rb
@@ -37,16 +37,14 @@ module FrancisCms
       private
 
       def options
-        if @syndicatable.try(:geolocated?) && @syndicatable.geolocated?
-          places = @client.reverse_geocode({ lat: @syndicatable.latitude, long: @syndicatable.longitude })
+        {}.tap do |opts|
+          if @syndicatable.try(:geolocated?)
+            places = @client.reverse_geocode({ lat: @syndicatable.latitude, long: @syndicatable.longitude })
 
-          if places.any?
-            { place: places.first }
-          else
-            {}
+            if places.any?
+              opts[:place] = places.first
+            end
           end
-        else
-          {}
         end
       end
     end

--- a/app/models/francis_cms/syndications/twitter.rb
+++ b/app/models/francis_cms/syndications/twitter.rb
@@ -1,0 +1,52 @@
+module FrancisCms
+  module Syndications
+    class Twitter
+      def initialize(syndicatable, canonical_url)
+        @syndicatable = syndicatable
+        @canonical_url = canonical_url
+
+        @client = ::Twitter::REST::Client.new({
+          consumer_key:        Rails.application.secrets.twitter_consumer_key,
+          consumer_secret:     Rails.application.secrets.twitter_consumer_secret,
+          access_token:        Rails.application.secrets.twitter_access_token,
+          access_token_secret: Rails.application.secrets.twitter_access_token_secret
+        })
+      end
+
+      def publish
+        url = @syndicatable.is_link? ? @syndicatable.url : @canonical_url
+
+        if @syndicatable.is_photo?
+          status = @syndicatable.title.truncate(90, omission: '…', separator: ' ')
+          tweet = @client.update_with_media("#{status} – #{url}", File.new(@syndicatable.photo.path), options)
+        else
+          status = @syndicatable.title.truncate(114, omission: '…', separator: ' ')
+          tweet = @client.update("#{status} – #{url}", options)
+        end
+
+        {
+          name: 'Twitter',
+          url: "https://twitter.com/#{tweet.user.screen_name}/status/#{tweet.id}"
+        }
+      rescue => error
+        # log `error.message`
+      end
+
+      private
+
+      def options
+        if @syndicatable.try(:geolocated?) && @syndicatable.geolocated?
+          places = @client.reverse_geocode({ lat: @syndicatable.latitude, long: @syndicatable.longitude })
+
+          if places.any?
+            { place: places.first }
+          else
+            {}
+          end
+        else
+          {}
+        end
+      end
+    end
+  end
+end

--- a/app/models/francis_cms/syndications/twitter.rb
+++ b/app/models/francis_cms/syndications/twitter.rb
@@ -1,16 +1,18 @@
 module FrancisCms
   module Syndications
     class Twitter
+      CLIENT_PARAMS = {
+        consumer_key:        Rails.application.secrets.twitter_consumer_key,
+        consumer_secret:     Rails.application.secrets.twitter_consumer_secret,
+        access_token:        Rails.application.secrets.twitter_access_token,
+        access_token_secret: Rails.application.secrets.twitter_access_token_secret
+      }
+
       def initialize(syndicatable, canonical_url)
         @syndicatable = syndicatable
         @canonical_url = canonical_url
 
-        @client = ::Twitter::REST::Client.new({
-          consumer_key:        Rails.application.secrets.twitter_consumer_key,
-          consumer_secret:     Rails.application.secrets.twitter_consumer_secret,
-          access_token:        Rails.application.secrets.twitter_access_token,
-          access_token_secret: Rails.application.secrets.twitter_access_token_secret
-        })
+        @client = ::Twitter::REST::Client.new(CLIENT_PARAMS)
       end
 
       def publish

--- a/app/views/francis_cms/archives/index.html.erb
+++ b/app/views/francis_cms/archives/index.html.erb
@@ -8,7 +8,7 @@
 	<%- if @years.any? -%>
 		<ol class="years-list">
 			<%- @years.each do |year| -%>
-				<li><%= link_to year, send("archives_yearly_#{resource_type}_path", year), rel: 'archives' %></li>
+				<li><%= link_to year, send("annual_archives_#{resource_type}_path", year), rel: 'archives' %></li>
 			<%- end -%>
 		</ol>
 	<%- else -%>

--- a/app/views/francis_cms/shared/_syndications_form.html.erb
+++ b/app/views/francis_cms/shared/_syndications_form.html.erb
@@ -30,21 +30,24 @@
 			<ul>
 				<%- if resource.can_syndicate_to_flickr? -%>
 					<li>
-						<%= form_tag send("#{resource_type.singularize}_flickr_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Flickr?", 'data-syndicate-to': 'flickr' do |f| %>
+						<%= form_tag send("#{resource_type.singularize}_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Flickr?", 'data-syndicate-to': 'flickr' do %>
+							<%= hidden_field_tag :silo, 'flickr', id: 'silo_flickr' %>
 							<button type="submit">Post to Flickr</button>
 						<% end %>
 					</li>
 				<%- end -%>
 				<%- if resource.can_syndicate_to_medium? -%>
 					<li>
-						<%= form_tag send("#{resource_type.singularize}_medium_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Medium?", 'data-syndicate-to': 'medium' do |f| %>
+						<%= form_tag send("#{resource_type.singularize}_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Medium?", 'data-syndicate-to': 'medium' do %>
+							<%= hidden_field_tag :silo, 'medium', id: 'silo_medium' %>
 							<button type="submit">Post to Medium</button>
 						<% end %>
 					</li>
 				<%- end -%>
 				<%- if resource.can_syndicate_to_twitter? -%>
 					<li>
-						<%= form_tag send("#{resource_type.singularize}_twitter_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Twitter?", 'data-syndicate-to': 'twitter' do |f| %>
+						<%= form_tag send("#{resource_type.singularize}_syndications_path", resource), class: 'automated-syndication-form', 'data-confirm': "Are you sure you want to syndicate this #{resource_type.singularize} to Twitter?", 'data-syndicate-to': 'twitter' do %>
+							<%= hidden_field_tag :silo, 'twitter', id: 'silo_twitter' %>
 							<button type="submit">Post to Twitter</button>
 						<% end %>
 					</li>

--- a/config/initializers/flickr.rb
+++ b/config/initializers/flickr.rb
@@ -1,6 +1,0 @@
-Flickr.configure do |config|
-  config.api_key             = Rails.application.secrets.flickr_api_key
-  config.shared_secret       = Rails.application.secrets.flickr_shared_secret
-  config.access_token_key    = Rails.application.secrets.flickr_access_token_key
-  config.access_token_secret = Rails.application.secrets.flickr_access_token_secret
-end

--- a/config/initializers/medium.rb
+++ b/config/initializers/medium.rb
@@ -1,1 +1,0 @@
-MediumClient = Medium::Client.new integration_token: Rails.application.secrets.medium_integration_token

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,6 +1,0 @@
-TwitterClient = Twitter::REST::Client.new do |config|
-  config.consumer_key        = Rails.application.secrets.twitter_consumer_key
-  config.consumer_secret     = Rails.application.secrets.twitter_consumer_secret
-  config.access_token        = Rails.application.secrets.twitter_access_token
-  config.access_token_secret = Rails.application.secrets.twitter_access_token_secret
-end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,12 +17,15 @@ en:
       create_notice: 'Successfully added that syndication.'
       create_alert: 'There was a problem saving that syndication. Mind trying again?'
       destroy_notice: 'You’ve successfully deleted that syndication. It’s gone for good!'
-      flickr_create_notice: 'Successfully posted that photo to Flickr.'
-      flickr_create_alert: 'There was a problem posting to Flickr. Mind trying again?'
-      medium_create_notice: 'Successfully published that post to Medium.'
-      medium_create_alert: 'There was a problem posting to Medium. Mind trying again?'
-      twitter_create_notice: 'Successfully posted that to Twitter'
-      twitter_create_alert: 'There was a problem posting to Twitter. Mind trying again?'
+      flickr:
+        create_notice: 'Successfully posted that photo to Flickr.'
+        create_alert: 'There was a problem posting to Flickr. Mind trying again?'
+      medium:
+        create_notice: 'Successfully published that post to Medium.'
+        create_alert: 'There was a problem posting to Medium. Mind trying again?'
+      twitter:
+        create_notice: 'Successfully posted that to Twitter.'
+        create_alert: 'There was a problem posting to Twitter. Mind trying again?'
     webmentions:
       create_notice: 'Thanks for submitting a webmention! It’s been placed in the queue for verification.'
       create_alert: 'There was a problem submitting that webmention. Mind trying again?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,8 +17,11 @@ en:
       create_notice: 'Successfully added that syndication.'
       create_alert: 'There was a problem saving that syndication. Mind trying again?'
       destroy_notice: 'You’ve successfully deleted that syndication. It’s gone for good!'
+      flickr_create_notice: 'Successfully posted that photo to Flickr.'
       flickr_create_alert: 'There was a problem posting to Flickr. Mind trying again?'
+      medium_create_notice: 'Successfully published that post to Medium.'
       medium_create_alert: 'There was a problem posting to Medium. Mind trying again?'
+      twitter_create_notice: 'Successfully posted that to Twitter'
       twitter_create_alert: 'There was a problem posting to Twitter. Mind trying again?'
     webmentions:
       create_notice: 'Thanks for submitting a webmention! It’s been placed in the queue for verification.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,18 +2,8 @@ FrancisCms::Engine.routes.draw do
   resources :links, :photos, :posts do
     resources :syndications, only: [:create, :destroy]
 
-    post 'syndications/twitter', to: 'syndications#twitter', as: 'twitter_syndications'
-
     get 'archives',       on: :collection, to: 'archives#index'
-    get 'archives/:year', on: :collection, to: 'archives#show', constraints: { year: /\d{4}/ }, as: 'archives_yearly'
-  end
-
-  resources :photos do
-    post 'syndications/flickr', to: 'syndications#flickr', as: 'flickr_syndications'
-  end
-
-  resources :posts do
-    post 'syndications/medium', to: 'syndications#medium', as: 'medium_syndications'
+    get 'archives/:year', on: :collection, to: 'archives#show', year: /\d{4}/, as: 'annual_archives'
   end
 
   resources :tags, only: [:index, :show]

--- a/lib/francis_cms/concerns/models/syndicatable.rb
+++ b/lib/francis_cms/concerns/models/syndicatable.rb
@@ -11,10 +11,10 @@ module FrancisCms::Concerns::Models::Syndicatable
 
   def can_syndicate_to_flickr?
     self.is_photo? &&
-    !Flickr.api_key.blank? &&
-    !Flickr.shared_secret.blank? &&
-    !Flickr.access_token_key.blank? &&
-    !Flickr.access_token_secret.blank?
+    !Rails.application.secrets.flickr_api_key.blank? &&
+    !Rails.application.secrets.flickr_shared_secret.blank? &&
+    !Rails.application.secrets.flickr_access_token_key.blank? &&
+    !Rails.application.secrets.flickr_access_token_secret.blank?
   end
 
   def can_syndicate_to_medium?
@@ -23,21 +23,21 @@ module FrancisCms::Concerns::Models::Syndicatable
   end
 
   def can_syndicate_to_twitter?
-    !TwitterClient.consumer_key.blank? &&
-    !TwitterClient.consumer_secret.blank? &&
-    !TwitterClient.access_token.blank? &&
-    !TwitterClient.access_token_secret.blank?
+    !Rails.application.secrets.twitter_consumer_key.blank? &&
+    !Rails.application.secrets.twitter_consumer_secret.blank? &&
+    !Rails.application.secrets.twitter_access_token.blank? &&
+    !Rails.application.secrets.twitter_access_token_secret.blank?
   end
 
   def is_link?
-    self.class.name.demodulize == 'Link'
+    self.class == FrancisCms::Link
   end
 
   def is_photo?
-    self.class.name.demodulize == 'Photo'
+    self.class == FrancisCms::Photo
   end
 
   def is_post?
-    self.class.name.demodulize == 'Post'
+    self.class == FrancisCms::Post
   end
 end


### PR DESCRIPTION
This PR…

- creates new models for Flickr, Medium, and Twitter syndication creation
- simplifies routing by `POST`ing all syndications to `create` and sorting it out from there
- moves several strings into `en.yml`
- refactors the `syndications_controller`, removing a bunch of code